### PR TITLE
Implement Rasengan beam clash

### DIFF
--- a/Naruto/scripts/hit_player.gml
+++ b/Naruto/scripts/hit_player.gml
@@ -61,11 +61,19 @@ case AT_NSPECIAL:
 			//when the initial projectile hits, spawn a multihit projectile.
 			if (has_hit) exit;
 			has_hit = true;
-			var rasen = create_hitbox(AT_NSPECIAL, 2, my_hitboxID.x, my_hitboxID.y);
-			rasen.spr_dir = my_hitboxID.spr_dir;
-			hit_player_obj.x += rasen.spr_dir * 10;
-			//pass on the charge strength of this projectile.
-			rasen.proj_nspecial_charge = my_hitboxID.proj_nspecial_charge;
+                        var rasen = create_hitbox(AT_NSPECIAL, 2, my_hitboxID.x, my_hitboxID.y);
+                        rasen.spr_dir = my_hitboxID.spr_dir;
+                        hit_player_obj.x += rasen.spr_dir * 10;
+                        //pass on the charge strength of this projectile.
+                        rasen.proj_nspecial_charge = my_hitboxID.proj_nspecial_charge;
+                        beam_newest_hbox = rasen;
+                        doing_goku_beam = true;
+                        beam_length = 64;
+                        beam_juice = rasen.proj_nspecial_charge;
+                        beam_juice_max = c_naruto_nspecial_max_charge;
+                        beam_clash_buddy = noone;
+                        beam_clash_timer = 0;
+                        beam_clash_timer_max = 120;
 		//break;
 		case 2:
 			//multihit projectile: drag player towards projectile.

--- a/Naruto/scripts/hitbox_init.gml
+++ b/Naruto/scripts/hitbox_init.gml
@@ -19,8 +19,18 @@ case 2:
     //change this as needed.
     time_between_hits = 6; //after the projectile's hitpause, the projectile will hit again after this many frames.
     final_hit_hbox_num = 3; //index of the 'final hit' hitbox to spawn, after this hitbox has hit a maximum number of times. set to 0 if you don't want a final hitbox.
-    proj_magnet_strength = 0.5; //amount by which the projectile draws the opponent into it on hit, like a magnet. 
+    proj_magnet_strength = 0.5; //amount by which the projectile draws the opponent into it on hit, like a magnet.
                                         //0 = no magnet, 1 = instant magnet. set to something in-between for a more natural-looking attack.
+
+    //mark this projectile as Naruto's active beam for clash logic
+    player_id.beam_newest_hbox = id;
+    player_id.doing_goku_beam = true;
+    player_id.beam_length = 64;
+    player_id.beam_juice = proj_nspecial_charge;
+    player_id.beam_juice_max = player_id.c_naruto_nspecial_max_charge;
+    player_id.beam_clash_buddy = noone;
+    player_id.beam_clash_timer = 0;
+    player_id.beam_clash_timer_max = 120;
        
        
     maximum_number_of_hits = 3; //the total number of hits for this projectile. don't change this here, this gets overwritten in hitbox_update.gml with the constants in user_event0.gml.

--- a/Naruto/scripts/hitbox_update.gml
+++ b/Naruto/scripts/hitbox_update.gml
@@ -49,9 +49,30 @@ switch (attack) {
 			hsp *= 0.75; break; 
 			
 		}
-		//specify which nspecial projectile is the multi-hit. 
-		//ignore hit_priority 1 hitboxes so that Kragg shards don't become multihits lol
-		if (hbox_num != 2) break;
+                //specify which nspecial projectile is the multi-hit.
+                //ignore hit_priority 1 hitboxes so that Kragg shards don't become multihits lol
+                if (hbox_num != 2) break;
+
+                //check for beam clash with other beam-based specials
+                if (player_id.beam_clash_buddy == noone) {
+                    var me = player_id;
+                    with oPlayer if "has_goku_beam" in self && doing_goku_beam && instance_exists(beam_newest_hbox) {
+                        var him = self;
+                        with beam_newest_hbox if distance_to_object(me.beam_newest_hbox) < 64 {
+                            me.beam_clash_buddy = him;
+                            him.beam_clash_buddy = me;
+                            with me sound_play(sfx_dbfz_hit_broken);
+                            me.beam_juice = max(me.beam_juice, 30);
+                            him.beam_juice = max(him.beam_juice, 30);
+                            me.beam_clash_timer_max = max(me.beam_clash_timer_max, him.beam_clash_timer_max);
+                            him.beam_clash_timer_max = max(me.beam_clash_timer_max, him.beam_clash_timer_max);
+                        }
+                    }
+                } else {
+                    with (player_id) if beam_clash_buddy != noone {
+                        beam_clash_logic();
+                    }
+                }
 		
 		//update the total number of hits, based on charge time.
 		if (hitbox_timer == 1) {
@@ -77,7 +98,13 @@ switch (attack) {
 				proj_hitpause = false;
 				
 				//if this projectile has hit its maximum number of times, destroy it.
-				if (hit_counter >= maximum_number_of_hits) destroyed = true;
+                                if (hit_counter >= maximum_number_of_hits) {
+                                    destroyed = true;
+                                    with (player_id) {
+                                        doing_goku_beam = false;
+                                        beam_newest_hbox = noone;
+                                    }
+                                }
 
 			}
 			else {
@@ -128,10 +155,14 @@ switch (attack) {
 				hitpause_inflicted = false;
 				
 				//if this is the final hit, and a 'final hitbox' has been specified, destroy this hitbox and spawn the 'final hitbox'.
-				if (hit_counter >= maximum_number_of_hits) {
-					destroyed = true;
-					
-					//spawn a 'final hit' hitbox, if specified.
+                                if (hit_counter >= maximum_number_of_hits) {
+                                        destroyed = true;
+                                        with (player_id) {
+                                            doing_goku_beam = false;
+                                            beam_newest_hbox = noone;
+                                        }
+
+                                        //spawn a 'final hit' hitbox, if specified.
 					if (final_hit_hbox_num == 0) break;
 					var final_hitbox = create_hitbox(attack, final_hit_hbox_num, x, y).spr_dir = spr_dir;
 					

--- a/Naruto/scripts/init.gml
+++ b/Naruto/scripts/init.gml
@@ -93,6 +93,18 @@ if (!custom_clone) {
 	dspecial_clones_out = 0;
 	dspecial_clone_out = 0;
     naruto_clone_despawn_article = noone; //reference of the article that will safely despawn clones. spawned in user_event3.gml.
+
+    //beam clash variables
+    has_goku_beam = true;
+    doing_goku_beam = false;
+    beam_newest_hbox = noone;
+    beam_clash_buddy = noone;
+    beam_clash_timer = 0;
+    beam_clash_timer_max = 120;
+    beam_length = 0;
+    beam_juice = 0;
+    beam_juice_max = 60 * 8;
+    c_naruto_nspecial_max_charge = 60 * 8;
     
     //move index constants. 
     //each clone needs their own index for certain moves.


### PR DESCRIPTION
## Summary
- enable beam clash for Naruto's Rasengan
- track Naruto's active beam projectile
- detect clashes with other beam moves
- store beam related variables during Rasengan

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687976b8e1ac83329792bd5beff859ed